### PR TITLE
Remove unixstickers.com sponser from Shop.

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,10 +83,6 @@
         src="https://image.spreadshirtmedia.net/Public/Media/spreadshirt/sprd_logo.svg"
         alt="SpreadShirt"
         style="max-width: 50px" />
-      <img
-        src="https://static.hoa-project.net/Image/Logo/UnixStickers.png"
-        alt="UnixStickers"
-        style="margin-left: 2em;" />
     </p>
 
     <h1>Products</h1>
@@ -140,36 +136,11 @@
         <div class="product__price">24.10€</div>
         <a href="https://shop.spreadshirt.fr/hoaproject/hoa+casual+t-shirt-A104219423" class="product__buy">Buy</a>
       </div>
-      <div class="product">
-        <img
-          src="https://www.unixstickers.com/image/cache/data/stickers/hoa/hoa.sh-600x600.png"
-          class="product__poster" />
-        <div class="product__title">Hoa Project Logo Shaped Sticker</div>
-        <div class="product__price">2.69$</div>
-        <a href="https://www.unixstickers.com/stickers/coding_stickers/hoa-project-php-libraries-logo-shaped-sticker" class="product__buy">Buy</a>
-      </div>
-      <div class="product">
-        <img
-          src="https://www.unixstickers.com/image/cache/data/stickers/hoa/hoa%20badge.sh-600x600.png"
-          class="product__poster" />
-        <div class="product__title">Hoa Project Logo Badge Sticker</div>
-        <div class="product__price">1.49$</div>
-        <a href="https://www.unixstickers.com/stickers/coding_stickers/hoa-php-libraries-logo-badge-sticker" class="product__buy">Buy</a>
-      </div>
-      <div class="product">
-        <img
-          src="https://www.unixstickers.com/image/cache/data/stickers/hoa/hoa-cloud.sh-600x600.png"
-          class="product__poster" />
-        <div class="product__title">Hoa Cloud Logo Shaped Sticker</div>
-        <div class="product__price">2.69$</div>
-        <a href="https://www.unixstickers.com/stickers/coding_stickers/hoa-cloud-php-libraries-shaped-sticker" class="product__buy">Buy</a>
-      </div>
     </div>
 
     <p class="tcenter">
       All these products are made with love by
-      <a href="https://shop.spreadshirt.fr/hoaproject">SpreadShirt</a> and
-      <a href="https://www.unixstickers.com/tag/hoa">UnixStickers</a>.
+      <a href="https://shop.spreadshirt.fr/hoaproject">SpreadShirt</a>.
     </p>
   </main>
 


### PR DESCRIPTION
Unixstickers.com is not a sponsor anymore, so we need to remove their products from the shop.